### PR TITLE
perform immediately when not in transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ is committed:
       when_committed { Resque.enqueue(RecalculateAggregateScores, self.id) }
     end
 
+Note that the block will run immediately when not in a transaction.
+
 ## Contributing
 
 1. [Fork it](https://github.com/PeopleAdmin/when_committed/fork_select)

--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -1,30 +1,42 @@
 require 'when_committed/version'
+require 'active_record'
 
-module WhenCommitted
-  module ActiveRecord
-    def self.included(base)
-      base.after_commit :run_when_committed_callbacks
-      base.after_rollback :clear_when_committed_callbacks
+module WhenCommitted::ActiveRecord
+
+  extend ActiveSupport::Concern
+
+  included do
+    class_eval do
+      after_commit :run_when_committed_callbacks
+      after_rollback :clear_when_committed_callbacks
     end
+  end
 
-    def when_committed(&block)
+  def when_committed(&block)
+    if in_transaction?
       when_committed_callbacks << block
+    else
+      block.call
     end
+  end
 
-    private
+  private
 
-    def when_committed_callbacks
-      @when_committed_callbacks ||= []
-    end
+  def when_committed_callbacks
+    @when_committed_callbacks ||= []
+  end
 
-    def run_when_committed_callbacks
-      when_committed_callbacks.each {|cb| cb.call}
-      clear_when_committed_callbacks
-    end
+  def run_when_committed_callbacks
+    when_committed_callbacks.each {|cb| cb.call}
+    clear_when_committed_callbacks
+  end
 
-    def clear_when_committed_callbacks
-      when_committed_callbacks.clear
-    end
+  def clear_when_committed_callbacks
+    when_committed_callbacks.clear
+  end
+
+  def in_transaction?
+    ActiveRecord::Base.connection.open_transactions != 0
   end
 end
 

--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -1,42 +1,39 @@
 require 'when_committed/version'
 require 'active_record'
 
-module WhenCommitted::ActiveRecord
-
-  extend ActiveSupport::Concern
-
-  included do
-    class_eval do
-      after_commit :run_when_committed_callbacks
-      after_rollback :clear_when_committed_callbacks
+module WhenCommitted
+  module ActiveRecord
+    def self.included(base)
+      base.after_commit :run_when_committed_callbacks
+      base.after_rollback :clear_when_committed_callbacks
     end
-  end
 
-  def when_committed(&block)
-    if in_transaction?
-      when_committed_callbacks << block
-    else
-      block.call
+    def when_committed(&block)
+      if in_transaction?
+        when_committed_callbacks << block
+      else
+        block.call
+      end
     end
-  end
 
-  private
+    private
 
-  def when_committed_callbacks
-    @when_committed_callbacks ||= []
-  end
+    def when_committed_callbacks
+      @when_committed_callbacks ||= []
+    end
 
-  def run_when_committed_callbacks
-    when_committed_callbacks.each {|cb| cb.call}
-    clear_when_committed_callbacks
-  end
+    def run_when_committed_callbacks
+      when_committed_callbacks.each {|cb| cb.call}
+      clear_when_committed_callbacks
+    end
 
-  def clear_when_committed_callbacks
-    when_committed_callbacks.clear
-  end
+    def clear_when_committed_callbacks
+      when_committed_callbacks.clear
+    end
 
-  def in_transaction?
-    ActiveRecord::Base.connection.open_transactions != 0
+    def in_transaction?
+      ::ActiveRecord::Base.connection.open_transactions != 0
+    end
   end
 end
 

--- a/lib/when_committed/version.rb
+++ b/lib/when_committed/version.rb
@@ -1,3 +1,3 @@
 module WhenCommitted
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/spec/when_committed_spec.rb
+++ b/spec/when_committed_spec.rb
@@ -4,7 +4,6 @@ require 'when_committed'
 describe "WhenCommitted" do
 
   before(:all) do
-    ActiveRecord::Base.raise_in_transactional_callbacks = true
     ActiveRecord::Base.establish_connection(adapter: :nulldb)
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Schema.define do
@@ -71,6 +70,7 @@ describe "WhenCommitted" do
         model.save
       end
       Widget.transaction do
+        model.name = "changed"
         model.save
       end
       expect(Backgrounder.jobs).to eq [:important_work]

--- a/spec/when_committed_spec.rb
+++ b/spec/when_committed_spec.rb
@@ -2,11 +2,13 @@ require 'active_record'
 require 'when_committed'
 
 describe "WhenCommitted" do
+
   before(:all) do
-    ActiveRecord::Base.establish_connection :adapter => :nulldb
+    ActiveRecord::Base.raise_in_transactional_callbacks = true
+    ActiveRecord::Base.establish_connection(adapter: :nulldb)
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Schema.define do
-      create_table(:widgets) do |t|
+      create_table(:widgets, id: false) do |t|
         t.string  :name
         t.integer :size
       end
@@ -16,9 +18,9 @@ describe "WhenCommitted" do
   it "provides a #when_committed method" do
     sample_class = Class.new(ActiveRecord::Base)
     model = sample_class.new
-    model.should_not respond_to(:when_committed)
+    expect(model).not_to respond_to(:when_committed)
     sample_class.send :include, WhenCommitted::ActiveRecord
-    model.should respond_to(:when_committed)
+    expect(model).to respond_to(:when_committed)
   end
 
   describe "#when_committed" do
@@ -27,20 +29,19 @@ describe "WhenCommitted" do
     end
     let(:model) { Widget.new }
 
-    it "runs the provided block after the transaction is committed" do
+    it "runs the provided block immediately when no transaction" do
       model.action_that_needs_follow_up_after_commit
-      model.save
-      Backgrounder.jobs.should == [:important_work]
+      expect(Backgrounder.jobs).to eq [:important_work]
     end
 
     it "does not run the provided block until the transaction is committed" do
       Widget.transaction do
         model.action_that_needs_follow_up_after_commit
-        Backgrounder.jobs.should be_empty
+        expect(Backgrounder.jobs).to be_empty
         model.save
-        Backgrounder.jobs.should be_empty
+        expect(Backgrounder.jobs).to be_empty
       end
-      Backgrounder.jobs.should == [:important_work]
+      expect(Backgrounder.jobs).to eq [:important_work]
     end
 
     it "does not run the provided block if the transaction is rolled back" do
@@ -52,7 +53,7 @@ describe "WhenCommitted" do
         end
       rescue Catastrophe
       end
-      Backgrounder.jobs.should be_empty
+      expect(Backgrounder.jobs).to be_empty
     end
 
     it "allows you to register multiple after_commit blocks" do
@@ -61,7 +62,7 @@ describe "WhenCommitted" do
         model.another_action_with_follow_up
         model.save
       end
-      Backgrounder.jobs.should == [:important_work,:more_work]
+      expect(Backgrounder.jobs).to eq [:important_work,:more_work]
     end
 
     it "does not run a registered block more than once" do
@@ -70,10 +71,9 @@ describe "WhenCommitted" do
         model.save
       end
       Widget.transaction do
-        model.name = "changed"
         model.save
       end
-      Backgrounder.should have(1).job
+      expect(Backgrounder.jobs).to eq [:important_work]
     end
   end
 end

--- a/spec/when_committed_spec.rb
+++ b/spec/when_committed_spec.rb
@@ -70,7 +70,6 @@ describe "WhenCommitted" do
         model.save
       end
       Widget.transaction do
-        model.name = "changed"
         model.save
       end
       expect(Backgrounder.jobs).to eq [:important_work]


### PR DESCRIPTION
#### Problem

Only blocks created inside transactions are performed.

For example assume a model with the following instance method. The job will never be enqueued when this method is called outside a transaction.

```
  def modify_model
    self.save
    when_committed do
      Resque.enqueue(SomeJobClass)
    end
  end
```
#### Solution

Blocks are performed immediately when created outside the context of a transaction.
#### Checkboxes
- [ ] code review
