### PR TITLE
introduce when_committed! to run immediately if not in a transaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,3 @@ language: ruby
 script: bundle exec rspec
 rvm:
 - 1.9.3
-notifications:
-  email: false
-  campfire:
-    rooms:
-    - secure: ! 'j8CJevgIDpE/cQwKm9z5uVY8nXmvQFOoQP/OIieEBMPd7IaSv6YVNMmjHju3
-
-        rKVL0471g0/+hfK1etfxeaygHjLVg1GmOnYH/CK97l3I3BnP5pEu7zz0wSs3
-
-        5Legz1OnsK11U1FAjfSkv088V3/IgyTVegU/SaSiSi03uUsRSVs='

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ is committed:
       when_committed { Resque.enqueue(RecalculateAggregateScores, self.id) }
     end
 
+`#when_committed!` will run the block immediately if there is no transaction.
+
 ## Contributing
 
 1. [Fork it](https://github.com/PeopleAdmin/when_committed/fork_select)

--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -11,6 +11,14 @@ module WhenCommitted
       when_committed_callbacks << block
     end
 
+    def when_committed!(&block)
+      if self.connection.open_transactions > 0
+        when_committed(&block)
+      else
+        block.call
+      end
+    end
+
     private
 
     def when_committed_callbacks

--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -1,4 +1,5 @@
 require 'when_committed/version'
+require 'active_record'
 
 module WhenCommitted
   module ActiveRecord
@@ -12,7 +13,7 @@ module WhenCommitted
     end
 
     def when_committed!(&block)
-      if self.connection.open_transactions > 0
+      if in_transcation?
         when_committed(&block)
       else
         block.call
@@ -32,6 +33,10 @@ module WhenCommitted
 
     def clear_when_committed_callbacks
       when_committed_callbacks.clear
+    end
+
+    def in_transcation?
+      ::ActiveRecord::Base.connection.open_transactions != 0
     end
   end
 end

--- a/lib/when_committed.rb
+++ b/lib/when_committed.rb
@@ -13,7 +13,7 @@ module WhenCommitted
     end
 
     def when_committed!(&block)
-      if in_transcation?
+      if ::ActiveRecord::Base.connection.open_transactions != 0
         when_committed(&block)
       else
         block.call
@@ -33,10 +33,6 @@ module WhenCommitted
 
     def clear_when_committed_callbacks
       when_committed_callbacks.clear
-    end
-
-    def in_transcation?
-      ::ActiveRecord::Base.connection.open_transactions != 0
     end
   end
 end

--- a/lib/when_committed/version.rb
+++ b/lib/when_committed/version.rb
@@ -1,3 +1,3 @@
 module WhenCommitted
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
If you call `when_committed` outside of a transaction, and never save the model, the block will never run. This may be exactly what you want, since the block might depend on changes to the model.

`when_committed!` is useful in scenarios where you don't know if the code will be called as part of a transaction or other model change. If it happens as part of transaction, wait until it is committed.
